### PR TITLE
BUGFIX: Add expire to cache tags

### DIFF
--- a/Classes/OptimizedRedisCacheBackend.php
+++ b/Classes/OptimizedRedisCacheBackend.php
@@ -103,7 +103,9 @@ class OptimizedRedisCacheBackend extends IndependentAbstractBackend implements T
         }
         foreach ($tags as $tag) {
             $this->redis->sAdd($this->buildKey('tag:' . $tag), $entryIdentifier);
+            $this->redis->expire($this->buildKey('tag:' . $tag), $lifetime);
             $this->redis->sAdd($this->buildKey('tags:' . $entryIdentifier), $tag);
+            $this->redis->expire($this->buildKey('tags:' . $entryIdentifier), $lifetime);
         }
         $this->redis->exec();
     }


### PR DESCRIPTION
The tags are never garbage collected from redis when the cache entry expires.