### PR TITLE
BUGFIX: Allow entries to have an unlimited lifetime

### DIFF
--- a/Classes/OptimizedRedisCacheBackend.php
+++ b/Classes/OptimizedRedisCacheBackend.php
@@ -112,7 +112,11 @@ class OptimizedRedisCacheBackend extends IndependentAbstractBackend implements T
         }
         foreach ($redisTags as $tag) {
             $this->redis->sAdd($tag['key'], $tag['value']);
-            $this->redis->expire($tag['key'], $tag['expire']);
+            if ($tag['expire'] > 0) {
+                $this->redis->expire($tag['key'], $tag['expire']);
+            } else {
+                $this->redis->persist($tag['key']);
+            }
         }
         $this->redis->exec();
     }

--- a/Tests/Functional/OptimizedRedisCacheBackendTest.php
+++ b/Tests/Functional/OptimizedRedisCacheBackendTest.php
@@ -11,6 +11,7 @@ namespace Sandstorm\OptimizedRedisCacheBackend\Tests\Functional;
  * source code.
  */
 
+use Neos\Cache\Backend\AbstractBackend;
 use Neos\Cache\Backend\RedisBackend;
 use Neos\Cache\EnvironmentConfiguration;
 use Neos\Cache\Tests\BaseTestCase;
@@ -31,7 +32,7 @@ use Sandstorm\OptimizedRedisCacheBackend\OptimizedRedisCacheBackend;
 class OptimizedRedisCacheBackendTest extends BaseTestCase
 {
     /**
-     * @var OptimizedRedisCacheBackendTest
+     * @var OptimizedRedisCacheBackend
      */
     private $backend;
 
@@ -192,5 +193,24 @@ class OptimizedRedisCacheBackendTest extends BaseTestCase
             $actualEntries[] = $key;
         }
         $this->assertEmpty($actualEntries, 'Entries should be empty');
+    }
+
+    /**
+     * @test
+     */
+    public function tagsForEntriesWithUnlimitedLifetimeArePersisted()
+    {
+        $this->backend->set('first_entry', 'foo', ['tag1'], AbstractBackend::UNLIMITED_LIFETIME);
+        $this->assertCount(1, $this->backend->findIdentifiersByTag('tag1'));
+    }
+
+    /**
+     * @test
+     */
+    public function tagsForEntriesWithUnlimitedLifetimeDontDeleteExistingTags()
+    {
+        $this->backend->set('first_entry', 'foo', ['tag1'], 3600);
+        $this->backend->set('second_entry', 'foo', ['tag1'], AbstractBackend::UNLIMITED_LIFETIME);
+        $this->assertCount(2, $this->backend->findIdentifiersByTag('tag1'));
     }
 }


### PR DESCRIPTION
Previously tags for cache entries with an unlimited lifetime (<= 0)
were not generated. Even more critical, existing tags were removed
in this case.

Background:

In Redis

    TTL <key> -1

does not remove the entry expiration but immediately marks the entry
expired.
The correct way to remove an expiration is

    PERSIST <key>

Fixes: #6